### PR TITLE
Fix issue #1: missing rest framework templates

### DIFF
--- a/nautilux_backend/nautilux_backend/settings.py
+++ b/nautilux_backend/nautilux_backend/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'corsheaders',
+    'rest_framework',
 ]
 
 MIDDLEWARE = [

--- a/nautilux_backend/nautilux_backend/settings.py
+++ b/nautilux_backend/nautilux_backend/settings.py
@@ -124,6 +124,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.11/howto/static-files/
 
 STATIC_URL = '/static/'
+STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',

--- a/nautilux_backend/nautilux_backend/urls.py
+++ b/nautilux_backend/nautilux_backend/urls.py
@@ -13,10 +13,13 @@ Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
+from django.conf import settings
 from django.conf.urls import url, include
+from django.conf.urls.static import static
 from django.contrib import admin
 
 urlpatterns = [
     url(r'^interventions/', include('interventions.urls')),
     url(r'^admin/', admin.site.urls),
-]
+] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+# TODO: static files should eventually be served properly

--- a/nautilux_backend/run_api.sh
+++ b/nautilux_backend/run_api.sh
@@ -1,6 +1,14 @@
 #!/bin/sh
 
+# Apply database migrations and load data
+echo "Applying database migrations and load data"
 python manage.py migrate
 python manage.py loaddata villes
 
+# Collect static files
+echo "Collecting static files"
+python manage.py collectstatic --noinput
+
+# Start Gunicorn server
+echo "Starting Gunicorn server"
 gunicorn nautilux_backend.wsgi:application --bind 0.0.0.0:8000


### PR DESCRIPTION
Ajout de `rest_framework` à `INSTALLED_APPS` dans la configuration de Django pour résoudre les problèmes liés aux templates HTML manquants.
